### PR TITLE
Added examples. YAML -> Vipps style

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,882 +1,878 @@
-swagger: '2.0'
+---
+swagger: "2.0"
 info:
-  description: |-
-    # Recurring payments
-
-    Recurring payments is used for subscription payments such as weekly dues for newspaper access, monthly dues for public transportation, etc.
-
-    1. A a draft agreement is initialized and the user is redirected for approval.
-    2. The user approves the agreement and the merchant can call GET on the agreement to verify the status
-    3. The merchant can start sending charges which will be charged the user in the future.
-
-    The merchant is responsible for checking the status of charges, and cancelling any user access if charges are failing (or contacting the user)
-
-
-    # Authenthication
-
-    For information regarding authenthication please read:
-    https://github.com/vippsas/vipps-recurring-api/blob/master/vipps-recurring-api.md#api-access-token
-  version: '1.0'
-  title: Recurring Payments Merchant API
-host: '10.78.12.69:10036'
-basePath: /mt1/vipps-recurring-merchant-api
-tags:
-  - name: agreement-controller
-    description: Agreement Controller
-  - name: charge-controller
-    description: Charge Controller
-  - name: draft-agreement-controller
-    description: Draft Agreement Controller
+  description: "# Recurring payments\n\nRecurring payments is used for subscription\
+    \ payments such as weekly dues for newspaper access, monthly dues for public transportation,\
+    \ etc.\n\n1. A a draft agreement is initialized and the user is redirected for\
+    \ approval.\n2. The user approves the agreement and the merchant can call GET\
+    \ on the agreement to verify the status\n3. The merchant can start sending charges\
+    \ which will be charged the user in the future.\n\nThe merchant is responsible\
+    \ for checking the status of charges, and cancelling any user access if charges\
+    \ are failing (or contacting the user)\n\n\n# Authenthication\n\nFor information\
+    \ regarding authenthication please read:\nhttps://github.com/vippsas/vipps-recurring-api/blob/master/vipps-recurring-api.md#api-access-token"
+  version: "1.0"
+  title: "Recurring Payments Merchant API"
+host: "10.78.12.69:10036"
+basePath: "/mt1/vipps-recurring-merchant-api"
+schemes:
+- "http"
 paths:
   /api/v1/agreement:
     get:
       tags:
-        - agreement-controller
-      summary: List Agreements
-      operationId: listUsingGET
+      - "agreement-controller"
+      summary: "List Agreements"
+      operationId: "listUsingGET"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: status
-          in: query
-          description: Filter by status
-          required: false
-          type: string
-          allowEmptyValue: false
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        description: "Filter by status"
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
       responses:
-        '200':
-          description: OK
+        200:
+          description: "OK"
           schema:
-            $ref: '#/definitions/Agreement'
-        '400':
-          description: Bad Request
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '401':
-          description: Unauthorized
-        '500':
-          description: Internal Server Error
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        500:
+          description: "Internal Server Error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Gateway Timeout
-      deprecated: false
-  '/api/v1/agreement/{agreementId}':
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+  /api/v1/agreement/{agreementId}:
     get:
       tags:
-        - agreement-controller
-      summary: Fetch an Agreement
-      operationId: getUsingGET
+      - "agreement-controller"
+      summary: "Fetch an Agreement"
+      operationId: "getUsingGET"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: Agreement ID
-          required: true
-          type: string
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
       responses:
-        '200':
-          description: OK
+        200:
+          description: "OK"
           schema:
-            $ref: '#/definitions/Agreement'
-        '400':
-          description: Bad Request
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '401':
-          description: Unauthorized
-        '404':
-          description: Agreement not found
-        '500':
-          description: Internal Server Error
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Agreement not found"
+        500:
+          description: "Internal Server Error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Gateway Timeout
-      deprecated: false
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
     post:
       tags:
-        - agreement-controller
-      summary: Update an Agreement
-      operationId: updateUsingPOST
+      - "agreement-controller"
+      summary: "Update an Agreement"
+      operationId: "updateUsingPOST"
       consumes:
-        - application/json
+      - "application/json"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - in: body
-          name: agreement
-          description: agreement
-          required: true
-          schema:
-            $ref: '#/definitions/Agreement'
-        - name: agreementId
-          in: path
-          description: Agreement ID
-          required: true
-          type: string
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Agreement"
       responses:
-        '200':
-          description: OK
+        200:
+          description: "OK"
           schema:
-            $ref: '#/definitions/Agreement'
-        '400':
-          description: Bad Request
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '401':
-          description: Unauthorized
-        '404':
-          description: Agreement not found
-        '500':
-          description: Internal Server Error
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Agreement not found"
+        500:
+          description: "Internal Server Error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Gateway Timeout
-      deprecated: false
-  '/api/v1/charge/{agreementId}':
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "Agreement ID"
+  /api/v1/charge/{agreementId}:
     get:
       tags:
-        - charge-controller
-      summary: List Charges
-      operationId: listUsingGET_1
+      - "charge-controller"
+      summary: "List Charges"
+      operationId: "listUsingGET_1"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: The agreement identifier (id)
-          required: true
-          type: string
-        - name: chargeStatus
-          in: query
-          description: The status of the charge
-          required: false
-          type: string
-          allowEmptyValue: false
-          enum:
-            - PENDING
-            - DUE
-            - CHARGED
-            - FAILED
-            - CANCELLED
-            - PARTIALLY_REFUNDED
-            - REFUNDED
-            - PROCESSING
+      - name: "chargeStatus"
+        in: "query"
+        required: false
+        type: "string"
+        description: "The status of the charge"
+        enum:
+        - "PENDING"
+        - "DUE"
+        - "CHARGED"
+        - "FAILED"
+        - "CANCELLED"
+        - "PARTIALLY_REFUNDED"
+        - "REFUNDED"
+        - "PROCESSING"
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
       responses:
-        '200':
-          description: Success
+        200:
+          description: "Success"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/ChargeResponse'
-        '400':
-          description: 'Invalid request, check your parameters'
+              $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '500':
-          description: Internal server error
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Timeout
-      deprecated: false
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
     post:
       tags:
-        - charge-controller
-      summary: |-
-        Create a new charge for a given agreement and customer.
-
-        An idempotency key must be provided to ensure idempotent requests.
-        Key size [1..30] characters.
-      operationId: createUsingPOST
+      - "charge-controller"
+      summary: "Create a new charge for a given agreement and customer.\n\nAn idempotency\
+        \ key must be provided to ensure idempotent requests.\nKey size [1..30] characters."
+      operationId: "createUsingPOST"
       consumes:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Idempotent-Key
-          in: header
-          description: Idempotent-Key
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: Agreement ID
-          required: true
-          type: string
-        - in: body
-          name: charge
-          description: charge
-          required: true
-          schema:
-            $ref: '#/definitions/CreateCharge'
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Idempotent-Key"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Idempotent-Key"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/CreateCharge"
       responses:
-        '200':
-          description: OK
+        200:
+          description: "OK"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '201':
-          description: Created
+            $ref: "#/definitions/ChargeResponse"
+        201:
+          description: "Created"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '204':
-          description: No Content (operation succeeded previously)
+            $ref: "#/definitions/ChargeResponse"
+        204:
+          description: "No Content (operation succeeded previously)"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '400':
-          description: 'Invalid request, check your parameters'
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '409':
-          description: 'Conflict, retry in a moment. (simultaneous idempotent requests)'
+              $ref: "#/definitions/FieldError"
+        409:
+          description: "Conflict, retry in a moment. (simultaneous idempotent requests)"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '500':
-          description: Internal server error
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Timeout
-      deprecated: false
-  '/api/v1/charge/{agreementId}/{chargeId}':
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The agreement identifier (id)"
+  /api/v1/charge/{agreementId}/{chargeId}:
     get:
       tags:
-        - charge-controller
-      summary: Fetch a Charge
-      operationId: getUsingGET_1
+      - "charge-controller"
+      summary: "Fetch a Charge"
+      operationId: "getUsingGET_1"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: agreementId
-          required: true
-          type: string
-        - name: chargeId
-          in: path
-          description: The charge identifier (id)
-          required: true
-          type: string
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
       responses:
-        '200':
-          description: Success
+        200:
+          description: "Success"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '400':
-          description: The requested charge does not exist
-        '500':
-          description: Internal server error
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "The requested charge does not exist"
+        500:
+          description: "Internal server error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Timeout
-      deprecated: false
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
     delete:
       tags:
-        - charge-controller
-      summary: Cancel a Charge
-      operationId: cancelUsingDELETE
+      - "charge-controller"
+      summary: "Cancel a Charge"
+      operationId: "cancelUsingDELETE"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: The agreement identifier (id)
-          required: true
-          type: string
-        - name: chargeId
-          in: path
-          description: The charge identifier (id)
-          required: true
-          type: string
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
       responses:
-        '200':
-          description: Success
+        200:
+          description: "Success"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '204':
-          description: No Content (operation succeeded previously)
+            $ref: "#/definitions/ChargeResponse"
+        204:
+          description: "No Content (operation succeeded previously)"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '400':
-          description: 'Invalid request, check your parameters'
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '409':
-          description: 'This charge is not in a deletable state, it may have already been charged to the user.'
-        '500':
-          description: Internal server error
+              $ref: "#/definitions/FieldError"
+        409:
+          description: "This charge is not in a deletable state, it may have already\
+            \ been charged to the user."
+        500:
+          description: "Internal server error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Timeout
-      deprecated: false
-  '/api/v1/charge/{agreementId}/{chargeId}/refund':
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "agreementId"
+    - name: "chargeId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The charge identifier (id)"
+  /api/v1/charge/{agreementId}/{chargeId}/refund:
     post:
       tags:
-        - charge-controller
-      summary: |-
-        Refund a charge
-
-        An idempotency key must be provided to ensure idempotent requests.
-        Key size [1..30] characters.
-      operationId: refundUsingPOST
+      - "charge-controller"
+      summary: "Refund a charge\n\nAn idempotency key must be provided to ensure idempotent\
+        \ requests.\nKey size [1..30] characters."
+      operationId: "refundUsingPOST"
       consumes:
-        - application/json
+      - "application/json"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Idempotent-Key
-          in: header
-          description: Idempotent-Key
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - name: agreementId
-          in: path
-          description: The agreement identifier (id)
-          required: true
-          type: string
-        - in: body
-          name: charge
-          description: charge
-          required: true
-          schema:
-            $ref: '#/definitions/RefundRequestDto'
-        - name: chargeId
-          in: path
-          description: The charge identifier (id)
-          required: true
-          type: string
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Idempotent-Key"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Idempotent-Key"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/RefundRequest"
       responses:
-        '200':
-          description: Success
+        200:
+          description: "Success"
           schema:
-            $ref: '#/definitions/ChargeResponse'
-        '400':
-          description: 'Invalid request, check your parameters'
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '404':
-          description: Charge does not exist (and never has)
+              $ref: "#/definitions/FieldError"
+        404:
+          description: "Charge does not exist (and never has)"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '500':
-          description: Internal server error
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Timeout
-      deprecated: false
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The agreement identifier (id)"
+    - name: "chargeId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The charge identifier (id)"
   /api/v1/draftAgreement:
     post:
       tags:
-        - draft-agreement-controller
-      summary: Send a new customer to Vipps in order to accept Agreement
-      operationId: registerUsingPOST
+      - "draft-agreement-controller"
+      summary: "Send a new customer to Vipps in order to accept Agreement"
+      operationId: "registerUsingPOST"
       consumes:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       produces:
-        - application/json;charset=UTF-8
+      - "application/json;charset=UTF-8"
       parameters:
-        - name: Authorization
-          in: header
-          description: Bearer 'auth token'
-          required: true
-          type: string
-        - name: Merchant-Serial-Number
-          in: header
-          description: The applicable merchant serial number currently being represented
-          required: true
-          type: string
-        - in: body
-          name: draftAgreement
-          description: draftAgreement
-          required: true
-          schema:
-            $ref: '#/definitions/DraftAgreement'
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/DraftAgreement"
       responses:
-        '200':
-          description: OK
+        200:
+          description: "OK"
           schema:
-            $ref: '#/definitions/DraftAgreementResponse'
-        '201':
-          description: OK
+            $ref: "#/definitions/DraftAgreementResponse"
+        201:
+          description: "OK"
           schema:
-            $ref: '#/definitions/DraftAgreementResponse'
-        '400':
-          description: Bad Request
+            $ref: "#/definitions/DraftAgreementResponse"
+        400:
+          description: "Bad Request"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '401':
-          description: Unauthorized
-        '422':
-          description: Unprocessable Entity (invalid json)
-        '500':
-          description: Internal Server Error
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        422:
+          description: "Unprocessable Entity (invalid json)"
+        500:
+          description: "Internal Server Error"
           schema:
-            type: array
+            type: "array"
             items:
-              $ref: '#/definitions/FieldErrorDto'
-        '503':
-          description: Service unavailable
-        '504':
-          description: Gateway Timeout
-      deprecated: false
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
 definitions:
   Agreement:
-    type: object
+    type: "object"
     required:
-      - interval
-      - intervalCount
-      - price
-      - productDescription
-      - productName
-      - status
+    - "interval"
+    - "intervalCount"
+    - "price"
+    - "productDescription"
+    - "productName"
+    - "status"
     properties:
       campaign:
-        description: A campaign is a temporary lowering of the agreement price. The end user will only see the campaign if today's date is between the start and end date
-        $ref: '#/definitions/campaign'
+        $ref: "#/definitions/campaign"
       currency:
-        type: string
-        example: NOK
+        type: "string"
+        description: "ISO-4217: https://www.iso.org/iso-4217-currency-codes.html"
+        default: "NOK"
         enum:
-          - NOK
+        - "NOK"
+        minLength: 3
+        maxLength: 3
+        pattern: "^[A-Z[3]$"
+        example: "NOK"
       id:
-        type: string
-        example: agr_5kSeqzFAMkfBbc
-        description: Uniquely identifies this agreement
-        readOnly: true
+        type: "string"
+        description: "Uniquely identifies this agreement"
+        maxLength: 36
+        example: "agr_5kSeqzFAMkfBbc"
       interval:
-        type: string
-        example: week
-        description: Interval for subscription
+        type: "string"
+        description: "Interval for subscription"
+        default: "MONTH"
         enum:
-          - day
-          - week
-          - month
+        - "DAY"
+        - "WEEK"
+        - "MONTH"
+        pattern: "^[A-Z]+$"
+        example: "WEEK"
       intervalCount:
-        type: integer
-        format: int32
-        example: 2
-        description: 'Number of intervals between charges. Example: interval=week, intervalCount=2 to be able to charge every two weeks. Charges should occur at least once a year.'
+        type: "integer"
+        format: "int32"
+        description: "Number of intervals between charges. Example: interval=week,\
+          \ intervalCount=2 to be able to charge every two weeks. Charges should occur\
+          \ at least once a year."
+        default: 1
         minimum: 1
         maximum: 31
-        exclusiveMinimum: false
-        exclusiveMaximum: false
+        example: 1
       price:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
         example: 7900
-        description: 'Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK'
-      productDescription:
-        type: string
-        example: Fin abonnementspakke
       productName:
-        type: string
-        example: Pluss-abonnement
-        description: Name of the product being subscribed to.
-      startDate:
-        type: string
-        example: '2019-01-01T00:00:00Z'
-        description: Date when agreement was started.
-        readOnly: true
+        type: "string"
+        description: "Product name (short)"
+        maxLength: 32
+        example: "Premier League subscription"
+      productDescription:
+        type: "string"
+        description: "Product description (longer)"
+        maxLength: 256
+        example: "Access to all games of English top football"
+      start:
+        type: "string"
+        format: "date"
+        description: "Date when agreement was started."
+        example: "2019-01-01"
+      stop:
+        type: "string"
+        format: "date"
+        description: "Date when agreement was stopped."
+        example: "2019-12-31"
       status:
-        type: string
-        example: ACTIVE
-        description: Status of the agreement.
+        type: "string"
+        description: "Status of the agreement."
         enum:
-          - PENDING
-          - ACTIVE
-          - STOPPED
-          - EXPIRED
-      stopDate:
-        type: string
-        example: '2019-01-01T00:00:00Z'
-        description: Date when agreement was stopped.
-        readOnly: true
-    title: Agreement
+        - "PENDING"
+        - "ACTIVE"
+        - "STOPPED"
+        - "EXPIRED"
+        example: "ACTIVE"
   ChargeResponse:
-    type: object
+    type: "object"
     required:
-      - amount
-      - amountRefunded
-      - dueDate
-      - id
-      - status
+    - "amount"
+    - "amountRefunded"
+    - "due"
+    - "id"
+    - "status"
     properties:
       amount:
-        type: integer
-        format: int32
-        example: 234
-        description: 'Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK'
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 49900
       amountRefunded:
-        type: integer
-        format: int32
-        example: 0
-        description: |-
-          The total amount which has been refunded, in case of status refund/partial refund.
-          Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK
+        type: "integer"
+        format: "int32"
+        description: "The total amount which has been refunded, in case of status\
+          \ refund/partial refund.\nTreated as a whole sum postfixed with two decimals\
+          \ for cents, eg 234 = 2.34 NOK"
+        example: 49900
       description:
-        type: string
-        example: Bla bla bla
-        readOnly: true
-      dueDate:
-        type: string
-        example: '2030-12-31T00:00:00Z'
+        type: "string"
+        description: "Description of the charge"
+        example: "Premier League subscription: September"
+      due:
+        type: "string"
+        format: "date"
+        description: "The due date for this charge"
+        example: "2030-12-31"
       id:
-        type: string
-        example: chg_WCVbcAbRCmu2zk
-        description: 'Unique identifier for this charge, up to 15 characters.'
+        type: "string"
+        description: "Unique identifier for this charge, up to 15 characters."
+        maxLength: 15
+        example: "chg_WCVbcAbRCmu2zk"
       status:
-        type: string
-        example: PENDING
+        type: "string"
+        default: "PENDING"
         enum:
-          - PENDING
-          - DUE
-          - CHARGED
-          - FAILED
-          - CANCELLED
-          - PARTIALLY_REFUNDED
-          - REFUNDED
-          - PROCESSING
+        - "PENDING"
+        - "DUE"
+        - "CHARGED"
+        - "FAILED"
+        - "CANCELLED"
+        - "PARTIALLY_REFUNDED"
+        - "REFUNDED"
+        - "PROCESSING"
+        example: "PENDING"
       transactionId:
-        type: string
-        example: 5001419121
-        description: Contains null until the status has reached CHARGED
-        readOnly: true
+        type: "string"
+        description: "Contains null until the status has reached CHARGED"
+        maxLength: 36
+        example: "5001419121"
       type:
-        type: string
-        example: RECURRING
-        readOnly: true
+        type: "string"
+        default: "RECURRING"
         enum:
-          - INITIAL
-          - RECURRING
-    title: ChargeResponse
+        - "INITIAL"
+        - "RECURRING"
+        example: "RECURRING"
   CreateCharge:
-    type: object
+    type: "object"
     required:
-      - amount
-      - description
-      - hasPriceChanged
+    - "amount"
+    - "description"
+    - "hasPriceChanged"
     properties:
       amount:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
         example: 234
-        description: 'Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK'
       currency:
-        type: string
-        example: NOK
+        type: "string"
         enum:
-          - NOK
+        - "NOK"
+        example: "NOK"
       description:
-        type: string
-        example: Månedsabonnement
-        description: This field is visible to the end user in-app
-      dueDate:
-        type: string
-        example: '2030-12-31'
-        description: yyyy-MM-dd
+        type: "string"
+        description: "This field is visible to the end user in-app"
+        example: "Månedsabonnement"
+      due:
+        type: "string"
+        format: "date"
+        description: "YYYY-MM-DD"
+        example: "2030-12-31"
       hasPriceChanged:
-        type: boolean
+        type: "boolean"
+        description: "If the amount exceeds the amount specified on the agreement,\
+          \ this field must be true to indicate that there is an update price for\
+          \ the parent subscription"
+        default: false
         example: false
-        description: 'If the amount exceeds the amount specified on the agreement, this field must be true to indicate that there is an update price for the parent subscription'
       retryDays:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "The service will attempt to charge the customer for N days [non\
+          \ inclusive], must be null or contain a value >= 0. If zero, no retries\
+          \ will be performed"
+        default: 5
         example: 5
-        description: 'The service will attempt to charge the customer for N days [non inclusive], must be null or contain a value >= 0. If zero, no retries will be performed'
-    title: CreateCharge
   DraftAgreement:
-    type: object
+    type: "object"
     required:
-      - currency
-      - interval
-      - intervalCount
-      - isApp
-      - merchantAgreementUrl
-      - merchantRedirectUrl
-      - price
-      - productDescription
-      - productName
+    - "currency"
+    - "interval"
+    - "intervalCount"
+    - "isApp"
+    - "merchantAgreementUrl"
+    - "merchantRedirectUrl"
+    - "price"
+    - "productDescription"
+    - "productName"
     properties:
       campaign:
-        description: A campaign is a temporary lowering of the agreement price. The end user will only see the campaign if today's date is between the start and end date
-        $ref: '#/definitions/campaign'
+        $ref: "#/definitions/campaign"
       currency:
-        type: string
-        example: NOK
+        type: "string"
+        description: "ISO-4217"
+        default: "NOK"
         enum:
-          - NOK
-      customerPhoneNumber:
-        type: string
-        example: '+4740000000'
-        description: Customers phone number (if available). Used to simplify the following Vipps interaction
+        - "NOK"
+        pattern: "^[A-Z][3]$"
+        example: "NOK"
+      customerMsisdn:
+        type: "string"
+        description: "Customers phone number (if available). Used to simplify the\
+          \ following Vipps interaction. MSISDN: http://www.msisdn.org"
+        maxLength: 15
+        example: "4740000000"
       initialCharge:
-        $ref: '#/definitions/InitialCharge'
+        $ref: "#/definitions/InitialCharge"
       interval:
-        type: string
-        example: WEEK
-        description: Interval for subscription
+        type: "string"
+        description: "Interval for subscription"
+        default: "MONTH"
         enum:
-          - YEAR
-          - MONTH
-          - WEEK
-          - DAY
+        - "YEAR"
+        - "MONTH"
+        - "WEEK"
+        - "DAY"
+        example: "WEEK"
       intervalCount:
-        type: integer
-        format: int32
-        example: 2
-        description: 'Number of intervals between charges. Example: interval=week, intervalCount=2 to be able to charge every two weeks. Charges should occur at least once a year'
+        type: "integer"
+        format: "int32"
+        description: "Number of intervals between charges. Example: interval=week,\
+          \ intervalCount=2 to be able to charge every two weeks. Charges should occur\
+          \ at least once a year"
         minimum: 1
         maximum: 31
-        exclusiveMinimum: false
-        exclusiveMaximum: false
+        example: 2
       isApp:
-        type: boolean
+        type: "boolean"
+        description: "If merchant is redirecting user from an app."
         example: true
-        description: If merchant is redirecting user from an app.
       merchantAgreementUrl:
-        type: string
-        example: 'https://www.merchant.no/subscriptions/1234/'
-        description: URL where Vipps can redirect the customer to view/administer their subscription.
+        type: "string"
+        description: "URL where Vipps can redirect the customer to view/administer\
+          \ their subscription."
+        example: "https://www.example.com/vipps-subscriptions/1234/"
       merchantRedirectUrl:
-        type: string
-        example: 'https://api.merchant.no/landing'
-        description: URL where customer should be redirected after the agreement has been approved/rejected in the Vipps mobile application.
+        type: "string"
+        description: "URL where customer should be redirected after the agreement\
+          \ has been approved/rejected in the Vipps mobile application."
+        example: "https://api.example.com/vipps-landing"
       price:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
         example: 7900
-        description: 'Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK'
-      productDescription:
-        type: string
-        example: Fin abonnementspakke
       productName:
-        type: string
-        example: Pluss-abonnement
-        description: Name of the product being subscribed to.
-    title: DraftAgreement
+        type: "string"
+        description: "Product name (short)"
+        maxLength: 32
+        example: "Premier League subscription"
+      productDescription:
+        type: "string"
+        description: "Product description (longer)"
+        maxLength: 256
+        example: "Access to all games of English top football"
   DraftAgreementResponse:
-    type: object
+    type: "object"
+    required:
+    - "agreementId"
+    - "agreementResource"
+    - "redirectToVippsUrl"
     properties:
       agreementResource:
-        type: string
-        example: 'https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc'
-        description: 'Reference to AgreementDto which user may agree to. Initially the AgreementDto is in a pendingUserApproval state, and it enters active state once user has approved in the Vipps application.'
-        readOnly: true
+        type: "string"
+        description: "Reference to Agreement which user may agree to. Initially the\
+          \ AgreementDto is in a pendingUserApproval state, and it enters active state\
+          \ once user has approved in the Vipps application."
+        example: "https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc"
       agreementId:
-        type: string
-        example: 'https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc'
-        description: 'Id of a AgreementDto which user may agree to. Initially the AgreementDto is in a pendingUserApproval state, and it enters active state once user has approved in the Vipps application.'
-        readOnly: true
-      redirectToVipps:
-        type: string
-        example: 'https://api.vipps.no/api/v1/register/U6JUjQXq8HQmmV'
-        description: Customer should be redirected to Vipps using this URL.
-        readOnly: true
-    title: DraftAgreementResponse
-  FieldErrorDto:
-    type: object
+        type: "string"
+        description: "Id of a AgreementDto which user may agree to. Initially the\
+          \ AgreementDto is in a pendingUserApproval state, and it enters active state\
+          \ once user has approved in the Vipps application."
+        example: "https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc"
+      redirectToVippsUrl:
+        type: "string"
+        description: "Customer should be redirected to Vipps using this URL."
+        example: "https://api.vipps.no/api/v1/register/U6JUjQXq8HQmmV"
+  FieldError:
+    type: "object"
     properties:
       code:
-        type: string
+        type: "string"
       field:
-        type: string
+        type: "string"
       message:
-        type: string
-    title: FieldErrorDto
+        type: "string"
   HealthCheckStatus:
-    type: object
+    type: "object"
+    required:
+    - "application"
+    - "cosmosDb"
+    - "paymentDb"
     properties:
       application:
-        type: boolean
+        type: "boolean"
       cosmosDb:
-        type: boolean
+        type: "boolean"
       paymentDb:
-        type: boolean
-    title: HealthCheckStatus
+        type: "boolean"
   InitialCharge:
-    type: object
+    type: "object"
     required:
-      - amount
-      - currency
-      - description
+    - "amount"
+    - "currency"
+    - "description"
     properties:
       amount:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
         example: 234
-        description: 'Treated as a whole sum postfixed with two decimals for cents, eg 234 = 2.34 NOK'
       currency:
-        type: string
-        example: NOK
+        type: "string"
+        description: "ISO-4217"
+        default: "EUR"
         enum:
-          - NOK
+        - "NOK"
+        pattern: "^[A-Z]{3}$"
+        example: "NOK"
       description:
-        type: string
-        example: Månedsabonnement
-        description: This field is visible to the end user in-app
-    title: InitialCharge
-    description: An initial charge for a new agreement. The charge will be executed immediately when the user approves the agreement.
-  RefundRequestDto:
-    type: object
+        type: "string"
+        description: "This field is visible to the end user in-app"
+        example: "Premier League subscription"
+    description: "An initial charge for a new agreement. The charge will be executed\
+      \ immediately when the user approves the agreement."
+  RefundRequest:
+    type: "object"
     properties:
       amount:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "The amount to refund"
         example: 100
-        description: The amount to refund
       description:
-        type: string
-        example: 'Forgot to apply discount, refunding 50%'
-        description: 'A textual description of the operation, which will be displayed in the users app.'
-    title: RefundRequestDto
+        type: "string"
+        description: "A textual description of the operation, which will be displayed\
+          \ in the users app."
+        maxLength: 256
+        example: "Forgot to apply discount, refunding 50%"
   campaign:
-    type: object
+    type: "object"
     properties:
       campaignPrice:
-        type: integer
-        format: int32
+        type: "integer"
+        format: "int32"
+        description: "The price of the agreement in the discount period. The lowering\
+          \ of the price will be displayed in-app."
         example: 1500
-        description: The price of the agreement in the discount period. The lowering of the price will be displayed in-app.
       end:
-        type: string
-        example: '2019-06-01T00:00:00Z'
-        description: The date and time the campaign ends. Needs to be UTC
-    title: campaign
+        type: "string"
+        format: "date-time"
+        description: "The date and time the campaign ends. Needs to be UTC"
+        example: "2019-06-01T00:00:00Z"

--- a/vipps-recurring-api.md
+++ b/vipps-recurring-api.md
@@ -2,7 +2,10 @@
 
 **Please note:** This API is not officially launched.
 
-The Vipps Recurring API delivers recurring payment functionality for a merchant to create a payment agreement with a customer for fixed interval payments. When the agreement is accepted by the end user the merchant can send charges that will be automatically processed on the due date.
+The Vipps Recurring API delivers recurring payment functionality for a merchant
+to create a payment agreement with a customer for fixed interval payments.
+When the agreement is accepted by the end user the merchant can send charges
+that will be automatically processed on the due date.
 
 **API documentation:** https://vippsas.github.io/vipps-recurring-api/
 
@@ -16,16 +19,13 @@ The Vipps Recurring API delivers recurring payment functionality for a merchant 
 
 ## How to perform recurring payments
 
-1. Draft an agreement to be approved with [`POST:/draftAgreement`](https://vippsas.github.io/vipps-recurring-api/#/draft-agreement-controller/registerUsingPOST). In the response an `agreementResource` is created with an `agreementId`. This `agreementResource` is a complete URL for performing a [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET) request.
+1. Draft a new agreement to be approved with [`POST:/draftAgreement`](https://vippsas.github.io/vipps-recurring-api/#/draft-agreement-controller/registerUsingPOST). In the response an `agreementResource` is created with an `agreementId`. This `agreementResource` is a complete URL for performing a [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET) request.
 
-2. The approved agreement is retrieved from [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET) with `"status":"active"` when customer approves the agreement.
+2. The approved agreement is retrieved from [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET) with `"status":"active"` when customer has approved the agreement.
 
-3. Create charges on the agreement with [`POST:/charge/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/createUsingPOST).
-
-4. Manage charges and agreements with:  
-* [`DELETE:/charge/{agreementId}/{chargeId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/cancelUsingDELETE)  
-* [`POST:/charge/{agreementId}/{chargeId}/refund`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/refundUsingPOST)  
-* [`POST:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/updateUsingPOST)
+3. Create a new on the agreement with [`POST:/charge/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/createUsingPOST). Note that charges are automatic, the merchant must actively create each charge. For every subsequent charge after the initial one:
+* Check that the agreement is still active (`"status":"active"`): [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET)
+* Create a new charge: [`POST:/charge/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/createUsingPOST)
 
 ### Step 1: Draft an agreement
 
@@ -43,11 +43,11 @@ The following code illustrates how to create an agreement:
   "merchantAgreementUrl": "https://vipps.io/terms",
   "price": 135,
   "productDescription": "Access to all games of English top football",
-  "productName": "Premier League Package"
+  "productName": "Premier League subscription"
 }
 ```
 
-Agreements can be initiated with or i without an initial charge.
+Agreements may be initiated with or without an initial charge.
 
 | # | Agreement      | Description                                                                          |
 |:--|:-----------|:-------------------------------------------------------------------------------------|
@@ -56,34 +56,46 @@ Agreements can be initiated with or i without an initial charge.
 
 **Intervals**\
 Intervals are defined with a interval type `YEAR`, `MONTH`, `WEEK`, or `DAY` and frequency as a count.\
+
 Example for a bi-weekly subscription:
 ```json
 "interval": "WEEK",
 "intervalCount": 2,
 ```
+
 Example for a quarterly subscription
 ```json
 "interval": "MONTH",
 "intervalCount": 3,
 ```
 
+Example for a yearly subscription
+```json
+"interval": "YEAR",
+"intervalCount": 1,
+```
+
 #### Initial charge
-Initial charge will be performed if the `initialcharge` is provided when creating an agreement. The `amount` has to correspond to the `price` of the agreement.
+Initial charge will be performed if the `initialcharge` is provided when
+creating an agreement. The `amount` has to correspond to the `price` of the agreement.
 
 ```json
 "initialCharge": {
-  "amount": 135,
+  "amount": 19900,
   "currency": "NOK",
-  "description": "Payment for September"
+  "description": "Premier League subscription: September"
 },
 ```
 
 #### Campaigns
-A campaign in recurring is a period where the price is lower than usual, and this is communicated to the customer with the original price shown for comparison. This Functionality is currently being developed and is subject to change.
+A campaign in recurring is a period where the price is lower than usual, and
+this is communicated to the customer with the original price shown for comparison.
+_This Functionality is currently being developed and is subject to change._
 
 <img src="images/CampaignExample.PNG" width="185">
 
 In order to start a campaign the campaign field has to be added either to the agreement [`POST:/draftAgreement`](https://vippsas.github.io/vipps-recurring-api/#/draft-agreement-controller/registerUsingPOST) for a campaign in the start of an agreement or update an agreement [`POST:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/updateUsingPOST) for an ongoing agreement.
+
 ```json
 "campaign": {
   "start": "2019-05-01T00:00:00Z",
@@ -97,8 +109,11 @@ In order to start a campaign the campaign field has to be added either to the ag
 | `start`            | Start date of campaign offer, if you are creating a agreement this is set to default now, and not an available variable  |
 | `end`            | End date of campaign offer, can not be in the past |
 | `originalPrice`       | The price that will be shown for comparison   |
+
+
 ### Step 2: Retrieve the approved agreement
-The agreement will be possible to accept for 5 minutes before it expires. When customer approves the agreement status will change to `active`
+The agreement will be possible to accept for 5 minutes before it expires.
+When the customer approves, the agreement status will change to `active`.
 
 [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET)
 ```json
@@ -110,14 +125,21 @@ The agreement will be possible to accept for 5 minutes before it expires. When c
   "price": 135,
   "merchantAgreementUrl": "https://vipps.io/terms",
   "productDescription": "Access to all games of English top football",
-  "productName": "Premier League Package",
+  "productName": "Premier League subscription",
   "startDate": "2018-08-22",
   "status": "ACTIVE",
 }
 ```
+#### Pausing an agreement
+If there should be a pause in an agreement, like a temporary stop of a
+subscription: Simply do not create any charges during the pause.
+
+#### 
 
 ### Step 3: Create a charge
-Create a charge for a given agreement. `dueDate` will define for which date the charge will be performed. `hasPriceChanged` must be `true` if the amount for the charge is different from price of the agreement.
+Create a charge for a given agreement. `dueDate` will define for which date
+the charge will be performed. `hasPriceChanged` must be `true` if the amount
+for the charge is different from price of the agreement.
 
 **NOTE:** The charges need to have a due date at least 8 days in the future.
 
@@ -134,16 +156,17 @@ Create a charge for a given agreement. `dueDate` will define for which date the 
 ```
 
 #### Charge retries
-Vipps will retry the charge for the number of days specified in `retryDays`. If `retryDays=0` it will be failed after the first attempt.
+Vipps will retry the charge for the number of days specified in `retryDays`.
+If `retryDays=0` it will be failed after the first attempt.
 
 ### Step 4: Manage charges and agreements
-Manage charges and agreement
 
 * Cancel charges with [`DELETE:/charge/{agreementId}/{chargeId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/cancelUsingDELETE).
 * Refund performed charges with [`POST:/charge/{agreementId}/{chargeId}/refund`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/refundUsingPOST).
 * Update agreements with [`POST:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/updateUsingPOST) in case there are any changes.
 
 #### Agreement states
+
 | # | State      | Description                                                                          |
 |:--|:-----------|:-------------------------------------------------------------------------------------|
 | 1 | `PENDING`  | Agreement has been created, but not approved by the user in the app yet |
@@ -186,9 +209,11 @@ This API returns the following HTTP statuses in the responses:
 All error responses contains an `error` object in the body, with details of the problem.
 
 ## Authentication and authorization - API access token
+
 For all product request we require the use of a `Authorization` header. This header is required by making a Access Token request with the values `client_id`, `client_secret` and `Ocp-Apim-Subscription-Key`. See the [Access Token swagger](https://vippsas.github.io/vipps-accesstoken-api/#/Authorization_Service/fetchAuthorizationTokenUsingPost) and the [getting started guide](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md#step-3) for more information.
 
 [`POST:/get`](https://vippsas.github.io/vipps-accesstoken-api/#/Authorization_Service/fetchAuthorizationTokenUsingPost)
+
 ```http
 POST https://apitest.vipps.no/accesstoken/get HTTP/1.1
 Host: apitest.vipps.no
@@ -198,7 +223,8 @@ Ocp-Apim-Subscription-Key:  <Ocp-Apim-Subscription-Key>
 
 ```
 
-The Ocp-Apim-Subscription-Key can be found in Vipps developer portal
+The `Ocp-Apim-Subscription-Key` can be found in Vipps developer portal.
+See the [Getting started guide](https://github.com/vippsas/vipps-developers/blob/master/vipps-getting-started.md).
 
 The request above will return a response similar to this, with the `access_token`:
 
@@ -217,7 +243,9 @@ HTTP 200 OK
 }
 ```
 
-Every request to the API, needs to have the `Authorization` header with the generated token and the `Ocp-Apim-Subscription-Key`. The header in the request to this API should look like this:
+Every request to the API, needs to have the `Authorization` header with the
+generated token and the `Ocp-Apim-Subscription-Key`. The header in the request
+to this API should look like this:
 
 ```http
 Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1Ni <continued>


### PR DESCRIPTION
As mentioned on Slack:

I’m working on a PR to tweak the Swagger for https://vippsas.github.io/vipps-recurring-api/

It’s mainly things like:
• Unambiguous descriptions
• Real examples, similar to in the Markdown guide (not “bla-bla-bla”)
• Min/max length where applicable
• Patterns (regex) where applicable
• Use built-in datatypes for date, not string (and use “due” and “start” instead of “dueDate” and “startDate”)

Plus some other potentially annoying changes. The PR can be discussed! :vipps:

I know it’s kind of late, but if we don’t make sure our APIs are following the same principles/standards/naming/etc, we’ll struggle - as will our customers