### PR TITLE
Changed description of POST:/charge/{agreementId} overview

### DIFF
--- a/vipps-recurring-api.md
+++ b/vipps-recurring-api.md
@@ -20,7 +20,9 @@ The Vipps Recurring API delivers recurring payment functionality for a merchant 
 
 2. The approved agreement is retrieved from [`GET:/agreement/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/agreement-controller/getUsingGET) with `"status":"active"` when customer approves the agreement.
 
-3. Create charges on the agreement with [`POST:/charge/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/createUsingPOST).
+3. Charge the customer for each period with [`POST:/charge/{agreementId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/createUsingPOST).<br>
+Each specific charge on an agreement must be scheduled by the merchant, a minimum of two days before the payment will occur. <br>
+**Note:** Vipps will *only* perform a payment transaction on an agreement after being told by the merchant through this endpoint.
 
 4. Manage charges and agreements with:  
 * [`DELETE:/charge/{agreementId}/{chargeId}`](https://vippsas.github.io/vipps-recurring-api/#/charge-controller/cancelUsingDELETE)  


### PR DESCRIPTION
Changed description of the charge/{agreementId} endpoint after questions from integrators so it's more clear how to use the API.