### PR TITLE
Plural, request/object, misc

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,7 +15,7 @@ info:
 
     For information regarding authenthication please read:
     https://github.com/vippsas/vipps-recurring-api/blob/master/vipps-recurring-api.md#authentication-and-authorization---api-access-token
-  version: '1.0.1'
+  version: '1.1.0'
   title: Recurring Payments Merchant API
 host: '10.78.12.69:10036'
 basePath: /mt1/vipps-recurring-merchant-api
@@ -27,7 +27,7 @@ tags:
   - name: draft-agreement-controller
     description: Draft Agreement Controller
 paths:
-  /api/v1/agreement:
+  /api/v1/agreements:
     get:
       tags:
       - "agreement-controller"
@@ -61,7 +61,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         401:
           description: "Unauthorized"
         500:
@@ -69,12 +69,12 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
           description: "Gateway Timeout"
-  /api/v1/agreement/{agreementId}:
+  /api/v1/agreements/{agreementId}:
     get:
       tags:
       - "agreement-controller"
@@ -103,7 +103,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         401:
           description: "Unauthorized"
         404:
@@ -113,7 +113,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -153,7 +153,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         401:
           description: "Unauthorized"
         404:
@@ -163,7 +163,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -174,7 +174,7 @@ paths:
       required: true
       type: "string"
       description: "Agreement ID"
-  /api/v1/charge/{agreementId}:
+  /api/v1/charges/{agreementId}:
     get:
       tags:
       - "charge-controller"
@@ -213,19 +213,19 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/ChargeResponse"
+              $ref: "#/definitions/Charge"
         400:
           description: "Invalid request, check your parameters"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         500:
           description: "Internal server error"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -260,38 +260,38 @@ paths:
         in: "body"
         required: true
         schema:
-          $ref: "#/definitions/CreateCharge"
+          $ref: "#/definitions/ChargeRequest"
       responses:
         200:
           description: "OK"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         201:
           description: "Created"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         204:
           description: "No Content (operation succeeded previously)"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         400:
           description: "Invalid request, check your parameters"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         409:
           description: "Conflict, retry in a moment. (simultaneous idempotent requests)"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         500:
           description: "Internal server error"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -302,7 +302,7 @@ paths:
       required: true
       type: "string"
       description: "The agreement identifier (id)"
-  /api/v1/charge/{agreementId}/{chargeId}:
+  /api/v1/charges/{agreementId}/{chargeId}:
     get:
       tags:
       - "charge-controller"
@@ -325,7 +325,7 @@ paths:
         200:
           description: "Success"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         400:
           description: "The requested charge does not exist"
         500:
@@ -333,7 +333,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -360,17 +360,17 @@ paths:
         200:
           description: "Success"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         204:
           description: "No Content (operation succeeded previously)"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         400:
           description: "Invalid request, check your parameters"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         409:
           description: "This charge is not in a deletable state, it may have already\
             \ been charged to the user."
@@ -379,7 +379,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -395,7 +395,7 @@ paths:
       required: true
       type: "string"
       description: "The charge identifier (id)"
-  /api/v1/charge/{agreementId}/{chargeId}/refund:
+  /api/v1/charges/{agreementId}/{chargeId}/refund:
     post:
       tags:
       - "charge-controller"
@@ -431,25 +431,25 @@ paths:
         200:
           description: "Success"
           schema:
-            $ref: "#/definitions/ChargeResponse"
+            $ref: "#/definitions/Charge"
         400:
           description: "Invalid request, check your parameters"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         404:
           description: "Charge does not exist (and never has)"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         500:
           description: "Internal server error"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -465,7 +465,7 @@ paths:
       required: true
       type: "string"
       description: "The charge identifier (id)"
-  /api/v1/draftAgreement:
+  /api/v1/agreements/draft:
     post:
       tags:
       - "draft-agreement-controller"
@@ -495,17 +495,17 @@ paths:
         200:
           description: "OK"
           schema:
-            $ref: "#/definitions/DraftAgreementResponse"
+            $ref: "#/definitions/DraftAgreementReference"
         201:
           description: "OK"
           schema:
-            $ref: "#/definitions/DraftAgreementResponse"
+            $ref: "#/definitions/DraftAgreementReference"
         400:
           description: "Bad Request"
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         401:
           description: "Unauthorized"
         422:
@@ -515,7 +515,7 @@ paths:
           schema:
             type: "array"
             items:
-              $ref: "#/definitions/FieldError"
+              $ref: "#/definitions/Error"
         503:
           description: "Service unavailable"
         504:
@@ -603,7 +603,7 @@ definitions:
         - "STOPPED"
         - "EXPIRED"
         example: "ACTIVE"
-  ChargeResponse:
+  Charge:
     type: "object"
     required:
     - "amount"
@@ -664,7 +664,7 @@ definitions:
         - "INITIAL"
         - "RECURRING"
         example: "RECURRING"
-  CreateCharge:
+  ChargeRequest:
     type: "object"
     required:
     - "amount"
@@ -786,7 +786,7 @@ definitions:
         description: "Product description (longer)"
         maxLength: 256
         example: "Access to all games of English top football"
-  DraftAgreementResponse:
+  DraftAgreementReference:
     type: "object"
     required:
     - "agreementId"
@@ -798,7 +798,7 @@ definitions:
         description: "Reference to Agreement which user may agree to. Initially the\
           \ Agreement is in a pendingUserApproval state, and it enters active state\
           \ once user has approved in the Vipps application."
-        example: "https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc"
+        example: "https://api.vipps.no/api/v1/agreements/agr_5kSeqzFAMkfBbc"
       agreementId:
         type: string
         example: 'agr_5kSeqzFAMkfBbc'
@@ -808,8 +808,8 @@ definitions:
         example: 'https://api.vipps.no/api/v1/register/U6JUjQXq8HQmmV'
         description: Customer should be redirected to Vipps using this URL.
         readOnly: true
-    title: DraftAgreementResponse
-  FieldError:
+    title: DraftAgreementReference
+  Error:
     type: object
     properties:
       code:


### PR DESCRIPTION
- Changed URIs from `/agreement/` and `/charge/` to `/agreements` and `/charges/`.
- Requests for creating a resource now send `ThingRequest` objects and get either a `Thing` or a `ThingReference` as response. 
- Changed URI with `/draftAgreement` to `/agreements/draft`.