### PR TITLE
Christian's version with lots of changes

### DIFF
--- a/docs/swagger.yaml.massefiks
+++ b/docs/swagger.yaml.massefiks
@@ -1,0 +1,891 @@
+---
+swagger: "2.0"
+info:
+  description: |-
+    # Recurring payments
+
+    Recurring payments is used for subscription payments such as weekly dues for newspaper access, monthly dues for public transportation, etc.
+
+    1. A a draft agreement is initialized and the user is redirected for approval.
+    2. The user approves the agreement and the merchant can call GET on the agreement to verify the status
+    3. The merchant can start sending charges which will be charged the user in the future.
+
+    The merchant is responsible for checking the status of charges, and cancelling any user access if charges are failing (or contacting the user)
+
+
+    # Authenthication
+
+    For information regarding authenthication please read:
+    https://github.com/vippsas/vipps-recurring-api/blob/master/vipps-recurring-api.md#authentication-and-authorization---api-access-token
+  version: '1.0'
+  title: Recurring Payments Merchant API
+host: '10.78.12.69:10036'
+basePath: /mt1/vipps-recurring-merchant-api
+tags:
+  - name: agreement-controller
+    description: Agreement Controller
+  - name: charge-controller
+    description: Charge Controller
+  - name: draft-agreement-controller
+    description: Draft Agreement Controller
+paths:
+  /api/v1/agreement:
+    get:
+      tags:
+      - "agreement-controller"
+      summary: "List Agreements"
+      operationId: "listUsingGET"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "status"
+        in: "query"
+        required: false
+        type: "string"
+        description: "Filter by status"
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        500:
+          description: "Internal Server Error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+  /api/v1/agreement/{agreementId}:
+    get:
+      tags:
+      - "agreement-controller"
+      summary: "Fetch an Agreement"
+      operationId: "getUsingGET"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Agreement not found"
+        500:
+          description: "Internal Server Error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+    post:
+      tags:
+      - "agreement-controller"
+      summary: "Update an Agreement"
+      operationId: "updateUsingPOST"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/Agreement"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/Agreement"
+        400:
+          description: "Bad Request"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Agreement not found"
+        500:
+          description: "Internal Server Error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "Agreement ID"
+  /api/v1/charge/{agreementId}:
+    get:
+      tags:
+      - "charge-controller"
+      summary: "List Charges"
+      operationId: "listUsingGET_1"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "chargeStatus"
+        in: "query"
+        required: false
+        type: "string"
+        description: "The status of the charge"
+        enum:
+        - "PENDING"
+        - "DUE"
+        - "CHARGED"
+        - "FAILED"
+        - "CANCELLED"
+        - "PARTIALLY_REFUNDED"
+        - "REFUNDED"
+        - "PROCESSING"
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    post:
+      tags:
+      - "charge-controller"
+      summary: "Create a new charge for a given agreement and customer.\n\nAn idempotency\
+        \ key must be provided to ensure idempotent requests.\nKey size [1..30] characters."
+      operationId: "createUsingPOST"
+      consumes:
+      - "application/json;charset=UTF-8"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Idempotent-Key"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Idempotent-Key"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/CreateCharge"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        201:
+          description: "Created"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        204:
+          description: "No Content (operation succeeded previously)"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        409:
+          description: "Conflict, retry in a moment. (simultaneous idempotent requests)"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The agreement identifier (id)"
+  /api/v1/charge/{agreementId}/{chargeId}:
+    get:
+      tags:
+      - "charge-controller"
+      summary: "Fetch a Charge"
+      operationId: "getUsingGET_1"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "The requested charge does not exist"
+        500:
+          description: "Internal server error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    delete:
+      tags:
+      - "charge-controller"
+      summary: "Cancel a Charge"
+      operationId: "cancelUsingDELETE"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        204:
+          description: "No Content (operation succeeded previously)"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        409:
+          description: "This charge is not in a deletable state, it may have already\
+            \ been charged to the user."
+        500:
+          description: "Internal server error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "agreementId"
+    - name: "chargeId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The charge identifier (id)"
+  /api/v1/charge/{agreementId}/{chargeId}/refund:
+    post:
+      tags:
+      - "charge-controller"
+      summary: "Refund a charge\n\nAn idempotency key must be provided to ensure idempotent\
+        \ requests.\nKey size [1..30] characters."
+      operationId: "refundUsingPOST"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Idempotent-Key"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Idempotent-Key"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/RefundRequest"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/ChargeResponse"
+        400:
+          description: "Invalid request, check your parameters"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        404:
+          description: "Charge does not exist (and never has)"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        500:
+          description: "Internal server error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Timeout"
+    parameters:
+    - name: "agreementId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The agreement identifier (id)"
+    - name: "chargeId"
+      in: "path"
+      required: true
+      type: "string"
+      description: "The charge identifier (id)"
+  /api/v1/draftAgreement:
+    post:
+      tags:
+      - "draft-agreement-controller"
+      summary: "Send a new customer to Vipps in order to accept Agreement"
+      operationId: "registerUsingPOST"
+      consumes:
+      - "application/json;charset=UTF-8"
+      produces:
+      - "application/json;charset=UTF-8"
+      parameters:
+      - name: "Authorization"
+        in: "header"
+        required: true
+        type: "string"
+        description: "Bearer 'auth token'"
+      - name: "Merchant-Serial-Number"
+        in: "header"
+        required: true
+        type: "string"
+        description: "The applicable merchant serial number currently being represented"
+      - name: "body"
+        in: "body"
+        required: true
+        schema:
+          $ref: "#/definitions/DraftAgreement"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/DraftAgreementResponse"
+        201:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/DraftAgreementResponse"
+        400:
+          description: "Bad Request"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        401:
+          description: "Unauthorized"
+        422:
+          description: "Unprocessable Entity (invalid json)"
+        500:
+          description: "Internal Server Error"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/FieldError"
+        503:
+          description: "Service unavailable"
+        504:
+          description: "Gateway Timeout"
+definitions:
+  Agreement:
+    type: "object"
+    required:
+    - "interval"
+    - "intervalCount"
+    - "price"
+    - "productDescription"
+    - "productName"
+    - "status"
+    properties:
+      campaign:
+        $ref: "#/definitions/campaign"
+      currency:
+        type: "string"
+        description: "ISO-4217: https://www.iso.org/iso-4217-currency-codes.html"
+        default: "NOK"
+        enum:
+        - "NOK"
+        minLength: 3
+        maxLength: 3
+        pattern: "^[A-Z[3]$"
+        example: "NOK"
+      id:
+        type: "string"
+        description: "Uniquely identifies this agreement"
+        maxLength: 36
+        example: "agr_5kSeqzFAMkfBbc"
+      interval:
+        type: "string"
+        description: "Interval for subscription"
+        default: "MONTH"
+        enum:
+        - "DAY"
+        - "WEEK"
+        - "MONTH"
+        pattern: "^[A-Z]+$"
+        example: "WEEK"
+      intervalCount:
+        type: "integer"
+        format: "int32"
+        description: "Number of intervals between charges. Example: interval=week,\
+          \ intervalCount=2 to be able to charge every two weeks. Charges should occur\
+          \ at least once a year."
+        default: 1
+        minimum: 1
+        maximum: 31
+        example: 1
+      price:
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 7900
+      productName:
+        type: "string"
+        description: "Product name (short)"
+        maxLength: 32
+        example: "Premier League subscription"
+      productDescription:
+        type: "string"
+        description: "Product description (longer)"
+        maxLength: 256
+        example: "Access to all games of English top football"
+      start:
+        type: "string"
+        format: "date"
+        description: "Date when agreement was started."
+        example: "2019-01-01"
+      stop:
+        type: "string"
+        format: "date"
+        description: "Date when agreement was stopped."
+        example: "2019-12-31"
+      status:
+        type: "string"
+        description: "Status of the agreement."
+        enum:
+        - "PENDING"
+        - "ACTIVE"
+        - "STOPPED"
+        - "EXPIRED"
+        example: "ACTIVE"
+  ChargeResponse:
+    type: "object"
+    required:
+    - "amount"
+    - "amountRefunded"
+    - "due"
+    - "id"
+    - "status"
+    properties:
+      amount:
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 49900
+      amountRefunded:
+        type: "integer"
+        format: "int32"
+        description: "The total amount which has been refunded, in case of status\
+          \ refund/partial refund.\nTreated as a whole sum postfixed with two decimals\
+          \ for cents, eg 234 = 2.34 NOK"
+        example: 49900
+      description:
+        type: "string"
+        description: "Description of the charge"
+        example: "Premier League subscription: September"
+      due:
+        type: "string"
+        format: "date"
+        description: "The due date for this charge"
+        example: "2030-12-31"
+      id:
+        type: "string"
+        description: "Unique identifier for this charge, up to 15 characters."
+        maxLength: 15
+        example: "chg_WCVbcAbRCmu2zk"
+      status:
+        type: "string"
+        default: "PENDING"
+        enum:
+        - "PENDING"
+        - "DUE"
+        - "CHARGED"
+        - "FAILED"
+        - "CANCELLED"
+        - "PARTIALLY_REFUNDED"
+        - "REFUNDED"
+        - "PROCESSING"
+        example: "PENDING"
+      transactionId:
+        type: "string"
+        description: "Contains null until the status has reached CHARGED"
+        maxLength: 36
+        example: "5001419121"
+      type:
+        type: "string"
+        default: "RECURRING"
+        enum:
+        - "INITIAL"
+        - "RECURRING"
+        example: "RECURRING"
+  CreateCharge:
+    type: "object"
+    required:
+    - "amount"
+    - "description"
+    - "hasPriceChanged"
+    properties:
+      amount:
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 234
+      currency:
+        type: "string"
+        enum:
+        - "NOK"
+        example: "NOK"
+      description:
+        type: "string"
+        description: "This field is visible to the end user in-app"
+        example: "Månedsabonnement"
+      due:
+        type: "string"
+        format: "date"
+        description: "YYYY-MM-DD"
+        example: "2030-12-31"
+      hasPriceChanged:
+        type: "boolean"
+        description: "If the amount exceeds the amount specified on the agreement,\
+          \ this field must be true to indicate that there is an update price for\
+          \ the parent subscription"
+        default: false
+        example: false
+      retryDays:
+        type: "integer"
+        format: "int32"
+        description: "The service will attempt to charge the customer for N days [non\
+          \ inclusive], must be null or contain a value >= 0. If zero, no retries\
+          \ will be performed"
+        default: 5
+        example: 5
+  DraftAgreement:
+    type: "object"
+    required:
+    - "currency"
+    - "interval"
+    - "intervalCount"
+    - "isApp"
+    - "merchantAgreementUrl"
+    - "merchantRedirectUrl"
+    - "price"
+    - "productDescription"
+    - "productName"
+    properties:
+      campaign:
+        $ref: "#/definitions/campaign"
+      currency:
+        type: "string"
+        description: "ISO-4217"
+        default: "NOK"
+        enum:
+        - "NOK"
+        pattern: "^[A-Z][3]$"
+        example: "NOK"
+      customerMsisdn:
+        type: "string"
+        description: "Customers phone number (if available). Used to simplify the\
+          \ following Vipps interaction. MSISDN: http://www.msisdn.org"
+        maxLength: 15
+        example: "4740000000"
+      initialCharge:
+        $ref: "#/definitions/InitialCharge"
+      interval:
+        type: "string"
+        description: "Interval for subscription"
+        default: "MONTH"
+        enum:
+        - "YEAR"
+        - "MONTH"
+        - "WEEK"
+        - "DAY"
+        example: "WEEK"
+      intervalCount:
+        type: "integer"
+        format: "int32"
+        description: "Number of intervals between charges. Example: interval=week,\
+          \ intervalCount=2 to be able to charge every two weeks. Charges should occur\
+          \ at least once a year"
+        minimum: 1
+        maximum: 31
+        example: 2
+      isApp:
+        type: "boolean"
+        description: "If merchant is redirecting user from an app."
+        example: true
+      merchantAgreementUrl:
+        type: "string"
+        description: "URL where Vipps can redirect the customer to view/administer\
+          \ their subscription."
+        example: "https://www.example.com/vipps-subscriptions/1234/"
+      merchantRedirectUrl:
+        type: "string"
+        description: "URL where customer should be redirected after the agreement\
+          \ has been approved/rejected in the Vipps mobile application."
+        example: "https://api.example.com/vipps-landing"
+      price:
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 7900
+      productName:
+        type: "string"
+        description: "Product name (short)"
+        maxLength: 32
+        example: "Premier League subscription"
+      productDescription:
+        type: "string"
+        description: "Product description (longer)"
+        maxLength: 256
+        example: "Access to all games of English top football"
+  DraftAgreementResponse:
+    type: "object"
+    required:
+    - "agreementId"
+    - "agreementResource"
+    - "redirectToVippsUrl"
+    properties:
+      agreementResource:
+        type: "string"
+        description: "Reference to Agreement which user may agree to. Initially the\
+          \ AgreementDto is in a pendingUserApproval state, and it enters active state\
+          \ once user has approved in the Vipps application."
+        example: "https://api.vipps.no/api/v1/agreement/agr_5kSeqzFAMkfBbc"
+      agreementId:
+        type: string
+        example: 'agr_5kSeqzFAMkfBbc'
+        description: 'Id of a AgreementDto which user may agree to. Initially the AgreementDto is in a pendingUserApproval state, and it enters active state once user has approved in the Vipps application.'
+        readOnly: true
+      redirectToVipps:
+        type: string
+        example: 'https://api.vipps.no/api/v1/register/U6JUjQXq8HQmmV'
+        description: Customer should be redirected to Vipps using this URL.
+        readOnly: true
+    title: DraftAgreementResponse
+  FieldErrorDto:
+    type: object
+    properties:
+      code:
+        type: "string"
+      field:
+        type: "string"
+      message:
+        type: "string"
+  HealthCheckStatus:
+    type: "object"
+    required:
+    - "application"
+    - "cosmosDb"
+    - "paymentDb"
+    properties:
+      application:
+        type: "boolean"
+      cosmosDb:
+        type: "boolean"
+      paymentDb:
+        type: "boolean"
+  InitialCharge:
+    type: "object"
+    required:
+    - "amount"
+    - "currency"
+    - "description"
+    properties:
+      amount:
+        type: "integer"
+        format: "int32"
+        description: "Treated as a whole sum postfixed with two decimals for cents,\
+          \ eg 234 = 2.34 NOK"
+        example: 234
+      currency:
+        type: "string"
+        description: "ISO-4217"
+        default: "EUR"
+        enum:
+        - "NOK"
+        pattern: "^[A-Z]{3}$"
+        example: "NOK"
+      description:
+        type: "string"
+        description: "This field is visible to the end user in-app"
+        example: "Premier League subscription"
+    description: "An initial charge for a new agreement. The charge will be executed\
+      \ immediately when the user approves the agreement."
+  RefundRequest:
+    type: "object"
+    properties:
+      amount:
+        type: "integer"
+        format: "int32"
+        description: "The amount to refund"
+        example: 100
+      description:
+        type: "string"
+        description: "A textual description of the operation, which will be displayed\
+          \ in the users app."
+        maxLength: 256
+        example: "Forgot to apply discount, refunding 50%"
+  campaign:
+    type: "object"
+    properties:
+      campaignPrice:
+        type: "integer"
+        format: "int32"
+        description: "The price of the agreement in the discount period. The lowering\
+          \ of the price will be displayed in-app."
+        example: 1500
+      end:
+        type: "string"
+        format: "date-time"
+        description: "The date and time the campaign ends. Needs to be UTC"
+        example: "2019-06-01T00:00:00Z"


### PR DESCRIPTION
Summary:

• Unambiguous descriptions
• Real examples, similar to in the Markdown guide (not “bla-bla-bla”)
• Min/max length where applicable
• Patterns (regex) where applicable
• Use built-in datatypes for date, not string (and use `due` and `start` instead of `dueDate` and `startDate`)
• Changed URIs from `/agreement/` and `/charge/` to `/agreements/` and `/charges/`.
• Requests for creating a resource now send `ThingRequest` objects and get either a `Thing` or a `ThingReference` as response.
• Changed URI with `/draftAgreement` to `/agreements/draft`.
• Examples, patterns and lengths for MSN, Authorization, etc
• Cancel charge: DELETE does not return the deleted charge (less chatty)
• Refund charge: Does not return a charge (less chatty)
• List charges: Enums for status filtering
• Shorter descriptions of operations
• Idempotency-Key, not Idempotent-Key (to match other APIs)
• Cancel charge: Added Idempotency-Key

https://recurring-wip.restlet.io 