### PR TITLE
Fix typo: s/rewuirements/requirements

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -810,7 +810,7 @@ components:
           description: URL where Vipps can send the customer to view/manage their
             subscription. Typically a "My page" where the user can change, pause, cancel, etc.
             We recommend letting users log in with Vipps, not with username and password.
-            We do not have any specific rewuirements for the security of the page.
+            We do not have any specific requirements for the security of the page.
           example: https://www.example.com/vipps-subscriptions/1234/
         merchantRedirectUrl:
           type: string


### PR DESCRIPTION
The typo was originally introduced in https://github.com/vippsas/vipps-recurring-api/commit/35af2d098f6fdc787d09bfb5bf333333eba34cc2

The typo in .md file has already been fixed in https://github.com/vippsas/vipps-recurring-api/commit/c0fd02dd20d8b777cf16ac6d268a81b92e2a6da5#diff-2d388668d91c4d3d1174018c8e6c5e9018a745e14944e09609c57f82a0e75124