### PR TITLE
Clarified isApp usage

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -111,14 +111,14 @@ paths:
         - Agreement v2 endpoints
       summary: Create a new Agreement, to be confirmed in Vipps
       description: |-
-        The API call allows merchants to create agreements for a user to accept. Once the agreement is drafted you will receive a `vippsConfirmationUrl`. 
+        The API call allows merchants to create agreements for a user to accept. Once the agreement is drafted you will receive a `vippsConfirmationUrl`.
         This is used to redirect the user to the Vipps landing page, or to the Vipps app if `"isApp":true` is used.
 
-        If the user accepts or rejects the agreement, the user will be redirected back to whichever URL has been passed in `merchantRedirectUrl`. 
-        You **have** to implement polling on the agreement to check when the status changes to active instead of relaying on the redirect back to the `merchantRedirectUrl`. 
+        If the user accepts or rejects the agreement, the user will be redirected back to whichever URL has been passed in `merchantRedirectUrl`.
+        You **have** to implement polling on the agreement to check when the status changes to active instead of relaying on the redirect back to the `merchantRedirectUrl`.
         We have no control over if a user is actually redirected back or not, this depends on what browser the user came from.
 
-        Please note the different use cases for `initialCharge` and `campaign`. And when to use `RESERVE_CAPTURE` instead of `DIRECT_CAPTURE` as transactionType. 
+        Please note the different use cases for `initialCharge` and `campaign`. And when to use `RESERVE_CAPTURE` instead of `DIRECT_CAPTURE` as transactionType.
         More information about this can be found in the API documentation.
       operationId: DraftAgreement
       parameters:
@@ -142,28 +142,28 @@ paths:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
                   price: 2500
                   productDescription: MyNews on web
                   productName: MyNews Digital
-                  skipLandingPage: true
+                  skipLandingPage: false
               With Initial Charge:
                 description: If you want the customer to pay to activate the agreement, you should add an initial charge. If the amount on the initial charge is not the same as the agreement/campaign price, it will show up as a separate payment bubble in the app.
                 value:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
                   price: 2500
                   productDescription: MyNews on web
                   productName: MyNews Digital
-                  skipLandingPage: true
+                  skipLandingPage: false
                   initialCharge:
                     amount: 100
                     currency: NOK
@@ -175,14 +175,14 @@ paths:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
                   price: 2500
                   productDescription: MyNews on web
                   productName: MyNews Digital
-                  skipLandingPage: true
+                  skipLandingPage: false
                   campaign:
                     campaignPrice: 100
                     end: 2022/02/28T00:00:00Z
@@ -192,14 +192,14 @@ paths:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
                   price: 2500
                   productDescription: MyNews on web
                   productName: MyNews Digital
-                  skipLandingPage: true
+                  skipLandingPage: false
                   campaign:
                     campaignPrice: 100
                     end: 2022/02/28T00:00:00Z
@@ -214,13 +214,13 @@ paths:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
                   productDescription: Power on web
                   productName: MyNews Digital
-                  skipLandingPage: true
+                  skipLandingPage: false
                   variableAmount:
                     suggestedMaxAmount: 3000
               With Profile Flow:
@@ -229,7 +229,7 @@ paths:
                   currency: NOK
                   interval: MONTH
                   intervalCount: 1
-                  isApp: true
+                  isApp: false
                   merchantRedirectUrl: https://merchant.redirect.url.no
                   merchantAgreementUrl: https://merchant.agreement.url.no
                   customerPhoneNumber: '45678272'
@@ -254,7 +254,7 @@ paths:
         - Agreement v2 endpoints
       summary: Fetch an Agreement
       description: |-
-        Fetch a single agreement for a user. 
+        Fetch a single agreement for a user.
         Recommended to use when polling for status changes after sending an agreement to a user.
       operationId: FetchAgreement
       parameters:
@@ -283,9 +283,9 @@ paths:
         - Agreement v2 endpoints
       summary: Update an Agreement
       description: |-
-        Updates the agreement. 
-        Note that when updating the status to "STOPPED", 
-        you can not re-activate it. If you want to pause an agreement, 
+        Updates the agreement.
+        Note that when updating the status to "STOPPED",
+        you can not re-activate it. If you want to pause an agreement,
         we suggest leaving the agreement active and skipping the creation of charges as long as the agreement is paused in your systems.
       operationId: UpdateAgreementPut
       parameters:
@@ -321,9 +321,9 @@ paths:
         - Agreement v2 endpoints
       summary: Update an Agreement
       description: |-
-        Updates the agreement. 
-        Note that when updating the status to "STOPPED", 
-        you can not re-activate it. If you want to pause an agreement, 
+        Updates the agreement.
+        Note that when updating the status to "STOPPED",
+        you can not re-activate it. If you want to pause an agreement,
         we suggest leaving the agreement active and skipping the creation of charges as long as the agreement is paused in your systems.
       operationId: UpdateAgreementPatch
       parameters:
@@ -360,7 +360,7 @@ paths:
         - Agreement v2 endpoints
       summary: Force accept an Agreement (Only available in test environment)
       description: |-
-        Forces an agreement to be accepted by the given customer phone number. 
+        Forces an agreement to be accepted by the given customer phone number.
         This endpoint can only be used in the test environment.
       operationId: acceptUsingPATCH
       parameters:
@@ -431,14 +431,14 @@ paths:
         - Agreement v3 endpoints
       summary: Create a new Agreement, to be confirmed in Vipps
       description: |-
-        The API call allows merchants to create agreements for a user to accept. Once the agreement is drafted you will receive a `vippsConfirmationUrl`. 
+        The API call allows merchants to create agreements for a user to accept. Once the agreement is drafted you will receive a `vippsConfirmationUrl`.
         This is used to redirect the user to the Vipps landing page, or to the Vipps app if `"isApp":true` is used.
 
-        If the user accepts or rejects the agreement, the user will be redirected back to whichever URL has been passed in `merchantRedirectUrl`. 
-        You **have** to implement polling on the agreement to check when the status changes to active instead of relaying on the redirect back to the `merchantRedirectUrl`. 
+        If the user accepts or rejects the agreement, the user will be redirected back to whichever URL has been passed in `merchantRedirectUrl`.
+        You **have** to implement polling on the agreement to check when the status changes to active instead of relaying on the redirect back to the `merchantRedirectUrl`.
         We have no control over if a user is actually redirected back or not, this depends on what browser the user came from.
 
-        Please note the different use cases for `initialCharge` and `campaign`. And when to use `RESERVE_CAPTURE` instead of `DIRECT_CAPTURE` as transactionType. 
+        Please note the different use cases for `initialCharge` and `campaign`. And when to use `RESERVE_CAPTURE` instead of `DIRECT_CAPTURE` as transactionType.
         More information about this can be found in the API documentation.
       operationId: DraftAgreementV3
       parameters:
@@ -623,7 +623,7 @@ paths:
         - Agreement v3 endpoints
       summary: Fetch an Agreement
       description: |-
-        Fetch a single agreement for a user. 
+        Fetch a single agreement for a user.
         Recommended to use when polling for status changes after sending an agreement to a user.
       operationId: FetchAgreementV3
       parameters:
@@ -652,9 +652,9 @@ paths:
         - Agreement v3 endpoints
       summary: Update an Agreement
       description: |-
-        Updates the agreement. 
-        Note that when updating the status to "STOPPED", 
-        you can not re-activate it. If you want to pause an agreement, 
+        Updates the agreement.
+        Note that when updating the status to "STOPPED",
+        you can not re-activate it. If you want to pause an agreement,
         we suggest leaving the agreement active and skipping the creation of charges as long as the agreement is paused in your systems.
       operationId: UpdateAgreementPatchV3
       parameters:
@@ -691,7 +691,7 @@ paths:
         - Agreement v3 endpoints
       summary: Force accept an Agreement (Only available in test environment)
       description: |-
-        Forces an agreement to be accepted by the given customer phone number. 
+        Forces an agreement to be accepted by the given customer phone number.
         This endpoint can only be used in the test environment.
       operationId: acceptUsingPATCHV3
       parameters:
@@ -759,7 +759,7 @@ paths:
         - Charge v2 endpoints
       summary: Create a new charge
       description: |-
-        Creates a new recurring charge *(payment)* that will charge the user on the date specified. 
+        Creates a new recurring charge *(payment)* that will charge the user on the date specified.
         If the payment fails, the charge will be retried based on `retryDays`.
       operationId: CreateCharge
       parameters:
@@ -824,12 +824,12 @@ paths:
         - Charge v2 endpoints
       summary: Cancel a Charge
       description: |-
-        Cancels a pending, due or reserved charge. 
-        When cancelling a charge that is `PARTIALLY_CAPTURED`, the remaining funds on the charge 
+        Cancels a pending, due or reserved charge.
+        When cancelling a charge that is `PARTIALLY_CAPTURED`, the remaining funds on the charge
         will be released back to the customer.
-        
-        Note if you cancel an agreement, 
-        there is no need to cancel the charges that belongs to the agreement. 
+
+        Note if you cancel an agreement,
+        there is no need to cancel the charges that belongs to the agreement.
         This will be done automatically by Vipps.
       operationId: CancelCharge
       parameters:
@@ -860,8 +860,8 @@ paths:
         - Charge v2 endpoints
       summary: Capture a reserved charge
       description: |-
-        Captures a reserved charge. 
-        Only charges with transactionType `RESERVE_CAPTURE` can be captured. 
+        Captures a reserved charge.
+        Only charges with transactionType `RESERVE_CAPTURE` can be captured.
       operationId: CaptureCharge
       parameters:
         - $ref: "#/components/parameters/Authorization"
@@ -961,7 +961,7 @@ paths:
         - Charge v3 endpoints
       summary: Create a new charge
       description: |-
-        Creates a new recurring charge *(payment)* that will charge the user on the date specified. 
+        Creates a new recurring charge *(payment)* that will charge the user on the date specified.
         If the payment fails, the charge will be retried based on `retryDays`.
       operationId: CreateChargeV3
       parameters:
@@ -1026,12 +1026,12 @@ paths:
         - Charge v3 endpoints
       summary: Cancel a Charge
       description: |-
-        Cancels a pending, due or reserved charge. 
-        When cancelling a charge that is `PARTIALLY_CAPTURED`, the remaining funds on the charge 
+        Cancels a pending, due or reserved charge.
+        When cancelling a charge that is `PARTIALLY_CAPTURED`, the remaining funds on the charge
         will be released back to the customer.
-        
-        Note if you cancel an agreement, 
-        there is no need to cancel the charges that belongs to the agreement. 
+
+        Note if you cancel an agreement,
+        there is no need to cancel the charges that belongs to the agreement.
         This will be done automatically by Vipps.
       operationId: CancelChargeV3
       parameters:
@@ -1058,8 +1058,8 @@ paths:
         - Charge v3 endpoints
       summary: Capture a reserved charge
       description: |-
-        Captures a reserved charge. 
-        Only charges with transactionType `RESERVE_CAPTURE` can be captured. 
+        Captures a reserved charge.
+        Only charges with transactionType `RESERVE_CAPTURE` can be captured.
         Can also do partial captures (captures a smaller part of the payment).
       operationId: CaptureChargeV3
       parameters:
@@ -1230,14 +1230,14 @@ components:
       schema:
         type: string
 
-    Idempotency-Key: 
+    Idempotency-Key:
       in: header
       name: Idempotency-Key
-      description: |- 
+      description: |-
         An Idempotency key must be provided to ensure idempotent requests.
         Key size can be between 1 to 40 characters.
       required: true
-      schema: 
+      schema:
         $ref: '#/components/schemas/IdempotencyKeyFormat'
 
     Merchant-Serial-Number:
@@ -1262,7 +1262,7 @@ components:
       description: Filter by status of the agreement.
       schema:
         $ref: "#/components/schemas/AgreementStatus"
-      
+
     CreatedAfterQuery:
       in: query
       name: createdAfter
@@ -1380,7 +1380,7 @@ components:
           example: 234
           description: |-
             The total amount which has been captured/charged, in case of status charged/partial capture.
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         refunded:
           type: integer
@@ -1388,7 +1388,7 @@ components:
           example: 0
           description: |-
             The total amount which has been refunded, in case of status refund/partial refund.
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         cancelled:
           type: integer
@@ -1397,7 +1397,7 @@ components:
           description: |-
             The total amount which has been cancelled.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
     ChargeHistory:
       type: array
@@ -1435,7 +1435,7 @@ components:
           example: 234
           description: |-
             The amount related to the operation.
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         idempotencyKey:
           type: string
@@ -1518,15 +1518,20 @@ components:
           format: int32
           description: |-
             Number of intervals between charges. Example: interval=week,
-            intervalCount=2 to be able to charge every two weeks. 
+            intervalCount=2 to be able to charge every two weeks.
             Charges should occur at least once a year.
           minimum: 1
           maximum: 31
           example: 2
         isApp:
           type: boolean
-          description: If merchant is redirecting user from an app or a mobile device.
-          example: true
+          description: |-
+            This parameter indicates whether payment request is triggered from
+            Mobile App or Web browser. Based on this value, response will be
+            redirect URL for Vipps landing page or deeplink URL to connect vipps
+            App. When isApp is set to true, URLs passed to Vipps will not be
+            validated as regular URLs.
+          example: false
         merchantAgreementUrl:
           type: string
           description: |-
@@ -1548,7 +1553,7 @@ components:
           description:  |-
             The price of the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         productName:
           type: string
@@ -1627,7 +1632,7 @@ components:
           description:  |-
             The price of the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         productName:
           type: string
@@ -1657,16 +1662,16 @@ components:
       properties:
         agreementResource:
           type: string
-          description: |- 
-            Reference of a an agreement which user may agree to. 
+          description: |-
+            Reference of a an agreement which user may agree to.
             Initially the agreement is in a pending state waiting for user approval.
             It enters active state once the user has approved it in Vipps.
           example: https://api.vipps.no/v2/agreement/agr_5kSeqz
         agreementId:
           type: string
-          description: |- 
-            Id of a an agreement which user may agree to. 
-            Initially the agreement is in a pending state waiting for user approval. 
+          description: |-
+            Id of a an agreement which user may agree to.
+            Initially the agreement is in a pending state waiting for user approval.
             It enters active state once the user has approved it in Vipps.
           example: agr_5kSeqz
         vippsConfirmationUrl:
@@ -1679,7 +1684,7 @@ components:
           example: https://api.vipps.no/v2/register/U6JUjQXq8HQmmV
         chargeId:
           type: string
-          description: |- 
+          description: |-
             The Id of the initialCharge if given, otherwise `null`.
             If an `orderId` is specified this is used as the `chargeId` otherwise it is auto generated.
           example: chr_5kSeqz
@@ -1694,8 +1699,8 @@ components:
         agreementId:
           type: string
           description: |-
-            Id of a an agreement which user may agree to. 
-            Initially the agreement is in a pending state waiting for user approval. 
+            Id of a an agreement which user may agree to.
+            Initially the agreement is in a pending state waiting for user approval.
             It enters active state once the user has approved it in Vipps.
           example: agr_5kSeqz
         vippsConfirmationUrl:
@@ -1747,10 +1752,10 @@ components:
           type: integer
           format: int32
           example: 49900
-          description: |- 
+          description: |-
             The price of the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
           minimum: 0
         productName:
@@ -1779,7 +1784,7 @@ components:
           $ref: "#/components/schemas/AgreementStatus"
         merchantAgreementUrl:
           type: string
-          description: |- 
+          description: |-
             URL where Vipps can send the customer to view/manage their
             subscription. Typically a "My page" where the user can change, pause, cancel, etc.
             We recommend letting users log in with Vipps, not with username and password.
@@ -1822,10 +1827,10 @@ components:
           type: integer
           format: int32
           example: 49900
-          description: |- 
+          description: |-
             The price of the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
           minimum: 0
         productName:
@@ -1849,7 +1854,7 @@ components:
           $ref: "#/components/schemas/AgreementStatus"
         merchantAgreementUrl:
           type: string
-          description: |- 
+          description: |-
             URL where Vipps can send the customer to view/manage their
             subscription. Typically a "My page" where the user can change, pause, cancel, etc.
             We recommend letting users log in with Vipps, not with username and password.
@@ -1878,10 +1883,10 @@ components:
           example: 3000
           minimum: 100
           maximum: 2000000
-          description: |- 
+          description: |-
             The suggested max amount that the customer should choose.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         campaign:
           $ref: '#/components/schemas/campaignV2'
@@ -1893,7 +1898,7 @@ components:
           description: |-
             The price of the agreement.
 
-            Price is specified in minor units. 
+            Price is specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         productName:
           type: string
@@ -1918,7 +1923,7 @@ components:
           description: Status of the agreement.
           enum:
             - STOPPED
-    
+
     PatchAgreementV3:
       title: PatchAgreement
       type: object
@@ -1929,10 +1934,10 @@ components:
           example: 3000
           minimum: 100
           maximum: 2000000
-          description: |- 
+          description: |-
             The suggested max amount that the customer should choose.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         productName:
           type: string
@@ -1962,10 +1967,10 @@ components:
           type: string
           example: agr_asdf123
           description: |-
-            Id of a an agreement which user may agree to. 
-            Initially the agreement is in a pending state waiting for user approval. 
+            Id of a an agreement which user may agree to.
+            Initially the agreement is in a pending state waiting for user approval.
             It enters active state once the user has approved it in Vipps.
-    
+
     variableAmount:
       title: Variable Amount request
       type: object
@@ -1978,12 +1983,12 @@ components:
           example: 3000
           minimum: 100
           maximum: 2000000
-          description: |- 
+          description: |-
             The suggested max amount that the customer should choose.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
-    
+
     variableAmountResponse:
       title: Variable Amount response
       type: object
@@ -1992,21 +1997,21 @@ components:
           type: integer
           format: int32
           example: 3000
-          description: |- 
+          description: |-
             The suggested max amount that the customer should choose.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         maxAmount:
           type: integer
           format: int32
           example: 3000
-          description: |- 
+          description: |-
             The max amount chosen by the customer.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
-    
+
     campaignV2:
       title: Campaign request
       type: object
@@ -2022,7 +2027,7 @@ components:
           description: |-
             The price of the agreement in the discount period. The lowering of the price will be displayed in-app.
 
-            Price is specified in minor units. 
+            Price is specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         end:
           type: string
@@ -2040,21 +2045,21 @@ components:
           description: |-
             The price of the agreement in the discount period. The lowering of the price will be displayed in-app.
 
-            Price is specified in minor units. 
+            Price is specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         start:
           type: string
           example: '2019-06-01T00:00:00Z'
-          description: |- 
-            The date and time the campaign ends. 
+          description: |-
+            The date and time the campaign ends.
             Needs to be UTC.
         end:
           type: string
           example: '2019-07-01T00:00:00Z'
-          description: |- 
-            The date and time the campaign ends. 
+          description: |-
+            The date and time the campaign ends.
             Needs to be UTC.
-    
+
     campaignV3:
       title: Campaign request
       type: object
@@ -2079,13 +2084,13 @@ components:
           description: |-
             The price of the agreement in the discount period. The lowering of the price will be displayed in-app.
 
-            Price is specified in minor units. 
+            Price is specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         eventDate:
           type: string
           example: '2019-06-01T00:00:00Z'
-          description: |- 
-            The date and time the campaign ends. 
+          description: |-
+            The date and time the campaign ends.
             Needs to be UTC.
         eventText:
           type: string
@@ -2120,19 +2125,19 @@ components:
           description: |-
             The price of the agreement in the discount period. The lowering of the price will be displayed in-app.
 
-            Price is specified in minor units. 
+            Price is specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         end:
           type: string
           example: '2019-06-01T00:00:00Z'
-          description: |- 
-            The date and time the campaign ends. 
+          description: |-
+            The date and time the campaign ends.
             Needs to be UTC.
         eventDate:
           type: string
           example: '2019-06-01T00:00:00Z'
-          description: |- 
-            The date and time the campaign ends. 
+          description: |-
+            The date and time the campaign ends.
             Needs to be UTC.
         eventText:
           type: string
@@ -2149,8 +2154,8 @@ components:
 
     InitialChargeV2:
       title: InitialCharge
-      description: |- 
-        An initial charge for a new agreement. 
+      description: |-
+        An initial charge for a new agreement.
         The charge will be processed immediately when the user approves the agreement.
       type: object
       required:
@@ -2166,7 +2171,7 @@ components:
           description: |-
             The amount that must be paid or approved before starting the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         currency:
           type: string
@@ -2180,7 +2185,7 @@ components:
         transactionType:
           type: string
           example: DIRECT_CAPTURE
-          description: The type of payment to be made. 
+          description: The type of payment to be made.
           enum:
             - RESERVE_CAPTURE
             - DIRECT_CAPTURE
@@ -2192,7 +2197,7 @@ components:
     InitialChargeV3:
       title: InitialCharge
       description: |-
-        An initial charge for a new agreement. 
+        An initial charge for a new agreement.
         The charge will be processed immediately when the user approves the agreement.
       type: object
       required:
@@ -2207,7 +2212,7 @@ components:
           description: |-
             The amount that must be payed or approved before starting the agreement.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         description:
           type: string
@@ -2240,10 +2245,10 @@ components:
           format: int32
           minimum: 100
           example: 234
-          description: |- 
+          description: |-
             Amount to be paid by the customer.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         currency:
           type: string
@@ -2258,7 +2263,7 @@ components:
           description: This field is visible to the end user in-app
         due:
           type: string
-          description: |- 
+          description: |-
             The date when the charge is due to be processed.
 
             Must be in the format `yyyy-MM-dd`
@@ -2291,10 +2296,10 @@ components:
           format: int32
           minimum: 100
           example: 234
-          description: |- 
+          description: |-
             Amount to be paid by the customer.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         TransactionType:
           $ref: "#/components/schemas/TransactionType"
@@ -2306,9 +2311,9 @@ components:
           description: This field is visible to the end user in-app
         due:
           type: string
-          description: |- 
+          description: |-
             The date when the charge is due to be processed.
-            
+
             If the charge is DIRECT_CAPTURE, the charge is processed and charged on due date.
             If the charge is RESERVE_CAPTURE, the charge is RESERVED on due date.
 
@@ -2336,7 +2341,7 @@ components:
           type: string
           example: chg_WCVbcAbRCmu2zk
           description: Unique identifier for this charge, up to 15 characters.
-      
+
     ChargeResponseV2:
       title: ChargeResponse
       type: object
@@ -2354,7 +2359,7 @@ components:
           type: integer
           format: int32
           example: 234
-          description: |- 
+          description: |-
             Amount to be paid by the customer.
 
             Amounts are specified in minor units.
@@ -2436,10 +2441,10 @@ components:
           type: integer
           format: int32
           example: 234
-          description: |- 
+          description: |-
             Amount to be paid by the customer.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 499 kr = 49900 øre.
         currency:
           $ref: "#/components/schemas/Currency"
@@ -2496,7 +2501,7 @@ components:
           $ref: "#/components/schemas/ChargeSummary"
         history:
           $ref: "#/components/schemas/ChargeHistory"
-    
+
     RefundRequest:
       title: Refund charge request
       type: object
@@ -2509,17 +2514,17 @@ components:
           format: int32
           minimum: 100
           example: 5000
-          description: |- 
+          description: |-
             The amount to refund on a captured/charged charge.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         description:
           type: string
           minimum: 1
           example: Forgot to apply discount, refunding 50%
           description: A textual description of the operation, which will be displayed in the user's app.
-    
+
     CaptureRequestV3:
       title: Capture charge request
       type: object
@@ -2532,17 +2537,17 @@ components:
           format: int32
           minimum: 100
           example: 5000
-          description: |- 
+          description: |-
             The amount to capture on a reserved charge.
 
-            Amounts are specified in minor units. 
+            Amounts are specified in minor units.
             For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 15 kr = 1500 øre.
         description:
           type: string
           minimum: 1
           example: Not all items were in stock. Partial capture.
           description: A textual description of the operation, which will be displayed in the user's app.
-    
+
     TimePeriod:
       title: Time Period request
       description: A period of time, defined by a unit (DAY, WEEK, ...) and a count (number of said units)
@@ -2603,7 +2608,7 @@ components:
         customerPhoneNumber:
           type: string
           example: '96969696'
-    
+
     ErrorFromAzure:
       type: object
       description: |-
@@ -2769,7 +2774,7 @@ components:
           description: 'Subject - Identifier for the end user'
           type: string
           example: 'c06c4afe-d9e1-4c5d-939a-177d752a0944'
-    
+
     UserinfoAccountInfo:
       type: object
       properties:
@@ -2782,7 +2787,7 @@ components:
         bank_name:
           description: "Bank connected to the account number"
           type: string
-    
+
     UserinfoAddress:
       type: object
       properties:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -4,7 +4,7 @@ info:
     Recurring payments is used for subscription payments, such as weekly dues for newspaper access, monthly dues for public transportation, etc.
     For details, see the [Recurring API Guide](https://vippsas.github.io/vipps-developer-docs/docs/APIs/recurring-api).
 
-  version: 2.6.8
+  version: 2.6.9
   title: Recurring Payments Merchant API
 
 servers:

--- a/vipps-recurring-api.md
+++ b/vipps-recurring-api.md
@@ -23,7 +23,7 @@ The overall flow is:
 To get access to the Recurring API in production, order Vipps "Faste Betalinger" (_recurring payments_) on
 [portal.vipps.no](https://portal.vipps.no).
 
-**IMPORTANT:** Before activating recurring payments for you, 
+**IMPORTANT:** Before activating recurring payments for you,
 Vipps must perform some extra Know Your Customer (KYC) checks, as required by [Finanstilsynet](https://www.finanstilsynet.no).
 You will also need to set up a direct agreement for use of "Vipps på Nett" ([Vipps eCom API](https://github.com/vippsas/vipps-ecom-api)).
 
@@ -38,9 +38,9 @@ See also:
 * [Integration checklist](vipps-recurring-api-checklist.md)
 * [FAQ](vipps-recurring-api-faq.md)
 
-API version: 1.0.0.
+API version: 2.0.0.
 
-Document version 2.5.9.
+Document version 2.5.10.
 
 <!-- START_TOC -->
 
@@ -407,10 +407,26 @@ The `vippsConfirmationUrl` should be used to redirect the user to the Vipps land
 page. The user can then confirm their identity and receive a prompt to accept the
 agreement within Vipps.
 
-The `isApp` property can be used to receive a deeplink URL, which in a mobile context,
-can be used to perform an app-switch, which removes the landing page step. This will only
-work if the user has Vipps installed on the same device as they are initiating
-the agreement from.
+If the payment is initiated in a native app, it is possible to explicitly force
+a `vipps://` URL by sending the `isApp` parameter in the initiate call:
+
+* `"isApp": false`: The URL is `https://`, which handles
+  everything automatically for you.
+  The phone's operating system will know, through "universal linking", that
+  the `https://api.vipps.no` URL should open the Vipps app, and not the default
+  web browser.
+  **Please note:** In some cases, this requires the user to approve that
+  Vipps is opened, but this is usually only the first time.
+* `"isApp": true`: The URL is for a deeplink, for forced app-switch to Vipps, with `vipps://`.
+  **Please note:** In our test environment (MT), the scheme is `vippsMT://`
+
+If the user does not have Vipps installed:
+
+* `"isApp":false`: The Vipps landing page will be shown,
+   and the user can enter a phone number and pay on a device with Vipps installed.
+* `"isApp": true`: The user will get an error message saying that the link can
+  not be opened.
+
 
 ### Intervals
 
@@ -459,7 +475,7 @@ Example for a subscription every 30th day:
 **Please note:** It is not possible to change intervals. If the user has
 accepted a yearly interval, the agreement cannot be changed to a monthly
 agreement. This requires a new agreement and a new consent from the user.
-It _is_ possible to make a monthly agreement and charge some months only. 
+It _is_ possible to make a monthly agreement and charge some months only.
 The general rule: Be as customer friendly and easy to understand
 as possible.
 
@@ -1487,8 +1503,8 @@ First a short description on the flows.
 ![Normal_agreement](images/normal_agreement.png)
 
 In the normal agreement, the user gets presented with the agreement, agrees to that, and gets sent to a confirmation screen.
-On the agreement we present the start date, the price of the agreements, the `productName` and the `product description` which are all defined by the merchant. 
-We also present an agreement explanation which is used to describe the agreement interval to the user. 
+On the agreement we present the start date, the price of the agreements, the `productName` and the `product description` which are all defined by the merchant.
+We also present an agreement explanation which is used to describe the agreement interval to the user.
 For example, for an agreement with `interval=WEEK` and `intervalCount=2`, the agreement explanation will be `hver 2.uke til du sier opp` or `every 2 weeks until cancelled`
 
 
@@ -1500,7 +1516,7 @@ This is the preferred flow whenever there is no campaigns or similar present.
 
 When an initial charge is present and the amount is different from the agreement price (or campaign price), the flow in Vipps will change. First the user gets presented with an overview over both the agreement and the initial charge. The user then proceed to confirm the agreement, and finally they will have to go through the actual payment of the initial charge.
 
-Here we also show `productName` and the agreement explanation on the agreement, as well as `description` on the initial charge. `productName` and `inital charge description` are defined by the merchant. The agreement explanation is created by Vipps based on the interval and the campaign if specified. 
+Here we also show `productName` and the agreement explanation on the agreement, as well as `description` on the initial charge. `productName` and `inital charge description` are defined by the merchant. The agreement explanation is created by Vipps based on the interval and the campaign if specified.
 
 Initial charges are designed to be used whenever there is an additional cost in setting up the agreement. This could be bundling of a mobile phone together with a mobile subscription, or a TV setup-box when becoming a customer at a cable company. We do not recommend this flow to be used purely for campaigns, as it could be confusing to the user.
 
@@ -1510,7 +1526,7 @@ As an example: If you have a campaign of 10 NOK for a digital media subscription
 
 ![flow_Campaign](images/flow-Campaign.png)
 
-When setting a campaign, this follows the normal agreement flow - with some changes. Instead of showing the ordinary price of the agreement, the campaign price will override this, and the ordinary price will be shown below together with information about when the change from the campaign price to the ordinary price will happen. 
+When setting a campaign, this follows the normal agreement flow - with some changes. Instead of showing the ordinary price of the agreement, the campaign price will override this, and the ordinary price will be shown below together with information about when the change from the campaign price to the ordinary price will happen.
 
 This is the preferred flow whenever you have a type of campaign where the subscription has a certain price for a certain interval or time, before it switches over to ordinary price.
 


### PR DESCRIPTION
isApp was not as well documented for the Recurring API as for the eCom API. 
* Copied isApp text from eCom API into OpenAPI spec and API guide
* Corrected examples, now used false for both isApp and skipLandingPage, as is default
* Changed fro "API version 1.0.0" to 2.0.0 in the guide.

isApp should be made optional in Recurring v3, as for eCom v2. The spec and guide must be updated for that, with the exact same text as for the eCom API.

Slack: https://vippsas.slack.com/archives/CCN8TE34J/p1664368834112559